### PR TITLE
flake: split configuration into modular structure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,19 +36,14 @@
           ...
         }:
         {
+          imports = [
+            ./nix
+          ];
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;
             overlays = [
               overlay
             ];
-          };
-          treefmt = {
-            projectRootFile = "flake.nix";
-            programs = {
-              nixfmt.enable = true;
-              nixfmt.package = pkgs.nixfmt-rfc-style;
-            };
-            flakeCheck = true;
           };
           packages = {
             default = pkgs.iedaScope.ieda;
@@ -57,37 +52,6 @@
               offlineDevBundle
               releaseDocker
               ;
-          };
-          devShells = {
-            default =
-              with pkgs;
-              mkShell {
-                buildInputs = [
-                  nixd
-                ];
-              };
-            ieda =
-              with pkgs;
-              mkShell {
-                inputsFrom = [ self'.packages.default ];
-                buildInputs = [
-                  cmake
-                ];
-              };
-
-            rtl2gds =
-              with pkgs;
-              mkShell {
-                buildInputs = [
-                  yosys
-                  ieda
-                  python312
-                  python312Packages.pyyaml
-                  python312Packages.orjson
-                  python312Packages.klayout
-                  python312Packages.pip
-                ];
-              };
           };
         };
     };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,8 @@
+{
+  imports =
+    let
+      modules = builtins.readDir ./modules;
+      subDirNames = builtins.attrNames modules;
+    in
+    map (name: ./modules/${name}) subDirNames;
+}

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+{
+  devShells = {
+    default =
+      with pkgs;
+      mkShell {
+        buildInputs = [
+          nixd
+        ];
+      };
+    ieda =
+      with pkgs;
+      mkShell {
+        inputsFrom = [ self'.packages.default ];
+        buildInputs = [
+          cmake
+        ];
+      };
+
+    rtl2gds =
+      with pkgs;
+      mkShell {
+        buildInputs = [
+          yosys
+          ieda
+          python312
+          python312Packages.pyyaml
+          python312Packages.orjson
+          python312Packages.klayout
+          python312Packages.pip
+        ];
+      };
+  };
+}

--- a/nix/modules/treefmt.nix
+++ b/nix/modules/treefmt.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+{
+  treefmt = {
+    projectRootFile = "flake.nix";
+    programs = {
+      nixfmt.enable = true;
+      nixfmt.package = pkgs.nixfmt-rfc-style;
+    };
+    flakeCheck = true;
+  };
+}


### PR DESCRIPTION
* Move devShells and treefmt configurations into separate modules under nix/modules
* Add imports directive to include nix modules directory
* Remove inline configurations from main flake.nix
* Add default.nix to automatically import all modules