### PR TITLE
nix(ieda): workaround for iEDA source and dependencies

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,4 +1,18 @@
-final: prev: {
+final: prev:
+let
+  # Prepare the submodules from the iEDA repository, see pkgs/ieda/submodules
+  submoduleNames = builtins.attrNames (builtins.readDir ./pkgs/ieda/submodules);
+  dropExt = with final.lib; map (name: (strings.removeSuffix ".nix" name) + "-src") submoduleNames;
+  path = map (subDir: ./pkgs/ieda/submodules/${subDir}) submoduleNames;
+  values = map (p: final.callPackage p { }) path;
+  submodulesAttrs = with final.lib; builtins.listToAttrs (zipListsWith nameValuePair dropExt values);
+in
+{
+  inherit (submodulesAttrs)
+    LSAssigner4iEDA-src
+    spectra-src
+    ;
+
   glog-lock = prev.glog.overrideAttrs (oldAttrs: rec {
     version = "0.6.0";
     src = final.fetchFromGitHub {

--- a/nix/pkgs/ieda/default.nix
+++ b/nix/pkgs/ieda/default.nix
@@ -8,6 +8,7 @@ lib.makeScope newScope (scope: {
   iedaSrc = iedaSrcFetcher {
     pr = null;
     iedaVersion = "0.1.0";
+    hash = null;
     remoteUrl = "https://gitee.com/oscc-project/iEDA";
   };
   rustpkgs = scope.callPackage ./rustpkgs { iedaSrc = scope.iedaSrc; };

--- a/nix/pkgs/ieda/patches/idrc.patch
+++ b/nix/pkgs/ieda/patches/idrc.patch
@@ -1,0 +1,42 @@
+diff --git a/src/operation/iDRC/interface/DRCInterface.hpp b/src/operation/iDRC/interface/DRCInterface.hpp
+index a83fce36f..9113680ef 100644
+--- a/src/operation/iDRC/interface/DRCInterface.hpp
++++ b/src/operation/iDRC/interface/DRCInterface.hpp
+@@ -30,7 +30,7 @@ namespace idb {
+ class IdbNet;
+ class IdbLayerRouting;
+ class IdbLayerCut;
+-enum class IdbLayerDirection : uint8_t;
++enum class IdbLayerDirection;
+ }  // namespace idb
+ 
+ namespace idrc {
+
+diff --git a/src/operation/iDRC/source/toolkit/utility/Utility.hpp b/src/operation/iDRC/source/toolkit/utility/Utility.hpp
+index 2283de1a6..84e050403 100644
+--- a/src/operation/iDRC/source/toolkit/utility/Utility.hpp
++++ b/src/operation/iDRC/source/toolkit/utility/Utility.hpp
+@@ -236,9 +236,9 @@ class Utility
+   static Rotation getRotation(GTLPolyInt& gtl_poly)
+   {
+     gtl::direction_1d gtl_rotation = gtl::winding(gtl_poly);
+-    if (gtl::direction_1d_enum::CLOCKWISE == gtl_rotation) {
++    if (gtl::direction_1d(gtl::direction_1d_enum::CLOCKWISE) == gtl_rotation) {
+       return Rotation::kClockwise;
+-    } else if (gtl::direction_1d_enum::COUNTERCLOCKWISE == gtl_rotation) {
++    } else if (gtl::direction_1d(gtl::direction_1d_enum::COUNTERCLOCKWISE) == gtl_rotation) {
+       return Rotation::kCounterclockwise;
+     } else {
+       return Rotation::kNone;
+@@ -248,9 +248,9 @@ class Utility
+   static Rotation getRotation(GTLHolePolyInt& gtl_holy_poly)
+   {
+     gtl::direction_1d gtl_rotation = gtl::winding(gtl_holy_poly);
+-    if (gtl::direction_1d_enum::CLOCKWISE == gtl_rotation) {
++    if (gtl::direction_1d(gtl::direction_1d_enum::CLOCKWISE) == gtl_rotation) {
+       return Rotation::kClockwise;
+-    } else if (gtl::direction_1d_enum::COUNTERCLOCKWISE == gtl_rotation) {
++    } else if (gtl::direction_1d(gtl::direction_1d_enum::COUNTERCLOCKWISE) == gtl_rotation) {
+       return Rotation::kCounterclockwise;
+     } else {
+       return Rotation::kNone;

--- a/nix/pkgs/ieda/src.nix
+++ b/nix/pkgs/ieda/src.nix
@@ -1,27 +1,18 @@
 {
+  lib,
   stdenv,
   fetchgit,
   fetchpatch,
-  lib,
-}:
-
-# Function that accepts PR number, remote URL, revision and patches
-{
-  pr ? null,
-  iedaVersion ? "2025-03-12",
-  remoteUrl ? "https://gitee.com/oscc-project/iEDA",
-  rev ? null,
-  hash ? null,
-  patches ? null,
-  ...
+  LSAssigner4iEDA-src,
+  spectra-src,
 }:
 
 let
-  # Default values when no PR is specified, version: "2025-03-12"
-  defaultRev = "3a066726aa9521991a46d603f041831361d3ba51";
-  defaultSha256 = "sha256-iPdp1xEje8bBumI/eqhvw0llg3NAzRb8pzc3fmWMwtU=";
-
-  # Default patches
+  defaultVersion = "0-unstable-2025-04-14";
+  defaultRemoteUrl = "https://gitee.com/oscc-project/iEDA";
+  # Default values when no PR is specified, version: "2025-04-14"
+  defaultRev = "51d198884cde2ecda643071a1a6cb4ec0e09d881";
+  defaultHash = "sha256-kDVEAttSqa8l7qcRs7MQiBgPbAKBExEQvIE8tc7PLpM="; # Default sha256 for the default revision (2025-04-14)
   defaultPatches = [
     # This patch is to fix the build error caused by the missing of the header file,
     # and remove some libs or path that they hard-coded in the source code.
@@ -31,7 +22,20 @@ let
       hash = "sha256-fLKsb/dgbT1mFCWEldFwhyrA1HSkKGMAbAs/IxV9pwM=";
     })
   ];
+in
 
+# Function that accepts PR number, remote URL, revision and patches
+{
+  pr ? null,
+  iedaVersion ? defaultVersion,
+  remoteUrl ? defaultRemoteUrl,
+  rev ? null,
+  hash ? defaultHash,
+  patches ? null,
+  ...
+}:
+
+let
   # Determine final values based on parameters
   finalRev =
     if rev != null then
@@ -41,11 +45,11 @@ let
     else
       defaultRev;
 
-  # When using a PR or custom rev, we can't predict sha256, so use lib.fakeHash
-  finalSha256 = if hash == null then lib.fakeHash else hash;
-
   # Use provided patches or default patches
   finalPatches = if patches == null then defaultPatches else defaultPatches ++ patches;
+
+  # Enable submodule fixup for older versions of iEDA. Versions older than the default
+  enableSubmodulesFixup = lib.versionOlder defaultVersion iedaVersion;
 in
 stdenv.mkDerivation {
   pname = "iEDA-src";
@@ -53,8 +57,14 @@ stdenv.mkDerivation {
   src = fetchgit {
     url = remoteUrl;
     rev = finalRev;
-    sha256 = finalSha256;
+    sha256 = hash;
+    fetchSubmodules = false;
   };
+
+  nativeBuildInputs = [
+    LSAssigner4iEDA-src
+    spectra-src
+  ];
 
   patches = finalPatches;
 
@@ -62,5 +72,11 @@ stdenv.mkDerivation {
   dontFixup = true;
   installPhase = ''
     cp -r . $out
+
+    ${lib.optionals enableSubmodulesFixup ''
+      # Copy third-party submodules to the output directory
+      cp -r ${LSAssigner4iEDA-src}/* $out/src/third_party/LSAssigner4iEDA
+      cp -r ${spectra-src}/* $out/src/third_party/spectra
+    ''}
   '';
 }

--- a/nix/pkgs/ieda/submodules/LSAssigner4iEDA.nix
+++ b/nix/pkgs/ieda/submodules/LSAssigner4iEDA.nix
@@ -1,0 +1,20 @@
+{
+  stdenv,
+  fetchgit,
+}:
+
+stdenv.mkDerivation {
+  pname = "LSAssigner4iEDA-src";
+  version = "0-unstable-2025-02-17";
+  src = fetchgit {
+    url = "https://gitee.com/li-jinyuan/LSAssigner4iEDA.git";
+    rev = "acb8e662dc886c24e64ea49a3dde0562becdb770";
+    sha256 = "sha256-rpxc1a2u/IUAn1+ZbuY0NNpm9OrZvWUJ/KeucewhKiI=";
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+  installPhase = ''
+    cp -r . $out
+  '';
+}

--- a/nix/pkgs/ieda/submodules/spectra.nix
+++ b/nix/pkgs/ieda/submodules/spectra.nix
@@ -1,0 +1,21 @@
+{
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "spectra-src";
+  version = "0-unstable-2025-02-17";
+  src = fetchFromGitHub {
+    owner = "yixuan";
+    repo = "spectra";
+    rev = "a29f37fe3ed1c2895b07b449fcb8f09bc0940e40";
+    sha256 = "sha256-75xZ4KTVqGhPyA5p5A0AmV4Z7mOMMZ194V2uZVesTaU=";
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+  installPhase = ''
+    cp -r . $out
+  '';
+}


### PR DESCRIPTION
* Add LSAssigner4iEDA and spectra submodules as dependencies
* Update iEDA source version to 2025-04-14 with new hash
* Add idrc.patch to fix build issues
* Modify src.nix to handle submodule dependencies