### PR TITLE
magic-vlsi: fix darwin

### DIFF
--- a/nix/pkgs/magic-vlsi/default.nix
+++ b/nix/pkgs/magic-vlsi/default.nix
@@ -7,11 +7,13 @@
   m4,
   cairo,
   libX11,
+  mesa,
   mesa_glu,
   ncurses,
   tcl,
   tcsh,
   tk,
+  fixDarwinDylibNames,
 }:
 
 stdenv.mkDerivation rec {
@@ -26,15 +28,20 @@ stdenv.mkDerivation rec {
     leaveDotGit = true;
   };
 
-  nativeBuildInputs = [
-    python3
-    git
-  ];
+  nativeBuildInputs =
+    [
+      python3
+      git
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      fixDarwinDylibNames
+    ];
 
   buildInputs = [
     cairo
     libX11
     m4
+    mesa
     mesa_glu
     ncurses
     tcl
@@ -55,32 +62,34 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    # Create the sys directory
-    mkdir -p ${placeholder "out"}/lib/magic/sys
+    # Fix necessary files missing in sys directory
+    mkdir -p $out/lib/magic/sys
 
-    # Install all technology files that were generated
+    shopt -s nullglob
+
     for techfile in scmos/*.tech; do
-      if [ -f "$techfile" ]; then
-        install -Dm644 "$techfile" ${placeholder "out"}/lib/magic/sys/$(basename "$techfile")
-      fi
+      install -Dm644 "$techfile" $out/lib/magic/sys/$(basename "$techfile")
     done
 
-    # Install all display styles
     for dstylefile in scmos/*.dstyle; do
-      if [ -f "$dstylefile" ]; then
-        install -Dm644 "$dstylefile" ${placeholder "out"}/lib/magic/sys/$(basename "$dstylefile")
-      fi
+      install -Dm644 "$dstylefile" $out/lib/magic/sys/$(basename "$dstylefile")
     done
 
-    # Install all color maps
     for cmapfile in scmos/*.cmap; do
-      if [ -f "$cmapfile" ]; then
-        install -Dm644 "$cmapfile" ${placeholder "out"}/lib/magic/sys/$(basename "$cmapfile")
-      fi
+      install -Dm644 "$cmapfile" $out/lib/magic/sys/$(basename "$cmapfile")
     done
   '';
 
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Fix dylib paths on macOS
+    install_name_tool -add_rpath ${mesa.out}/lib $out/lib/magic/tcl/tclmagic.dylib
+    install_name_tool -add_rpath ${mesa_glu.out}/lib $out/lib/magic/tcl/tclmagic.dylib
+    install_name_tool -add_rpath ${mesa.out}/lib $out/lib/magic/tcl/magicexec
+    install_name_tool -add_rpath ${mesa_glu.out}/lib $out/lib/magic/tcl/magicexec
+  '';
+
   env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
 
   meta = with lib; {
     description = "VLSI layout tool written in Tcl";


### PR DESCRIPTION
* Bump magic-vlsi to 8.3.530
* Fix technology missing:
```shell
  Magic 8.3 revision 526 - Compiled on Mon Apr 21 21:06:36 UTC 2025.
  Starting magic under Tcl interpreter
  Using the terminal as the console.
  WARNING: RLIMIT_NOFILE is above 1024 and Tcl_Version<9 this may cause runtime issues [rlim_cur=65536]
  Using NULL graphics device.
  Could not find file 'minimum.tech' in any of these directories:
           . $CAD_ROOT/magic/sys $CAD_ROOT/magic/sys/current
  Cannot load technology "minimum" for initialization
```
* Fix dylib rpath on darwin
```
dlopen(/nix/store/dsf1n9g7wsfhwjqyvkqz96y6766wnamh-magic-vlsi-8.3.530/lib/magic/tcl/tclmagic.dylib, 0x0005): Library not loaded: @rpath/libgallium-25.1.4.dylib
  Referenced from: <F1113A61-C93D-3CB2-8233-CB787FD91851> /nix/store/kh353hyqjjfrdwaad9vyxjr02gjyzdhd-mesa-25.1.4/lib/libGL.1.dylib
  Reason: tried: '/usr/local/lib/libgallium-25.1.4.dylib' (no such file), '/usr/lib/libgallium-25.1.4.dylib' (no such file, not in dyld cache)
% 
```