### PR TITLE
ci: add ARX bundle build and restructure artifact names and deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,16 +30,24 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Build iEDA
         run: nix build -L '.#iedaUnstable' --accept-flake-config
-      - name: Build iEDA Bundle
+      - name: Build iEDA PRM Bundle
         run: nix bundle -L --bundler github:NixOS/bundlers#toRPM '.#iedaUnstable' --accept-flake-config
-      - name: Upload iEDA Offline Bundle
+      - name: Upload iEDA RPM Offline Bundle
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: iEDA-RPM-Bundle
+          path: rpm-single-ieda
+      - name: Build iEDA ARX Bundle
+        run: nix bundle -L '.#iedaUnstable' --accept-flake-config
+      - name: Upload iEDA ARX Offline Bundle
         uses: actions/upload-artifact@v4.6.2
         with:
           name: iEDA-Bundle
-          path: rpm-single-ieda
+          path: ieda-arx
 
   build-docker:
     name: Build Docker on ${{ matrix.os }}
+    needs: [build-bundle]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
* Build both RPM and ARX bundles in CI workflow
* Rename RPM bundle artifact to iEDA-RPM-Bundle for clarity
* Add ARX bundle artifact as iEDA-Bundle
* Make docker build job depend on bundle build completion