### PR TITLE
yosysWithSlang: set YOSYS_PLUGIN_PATH for plugin discovery

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -23,6 +23,12 @@ in
       final.yosys-slang
     ]).overrideAttrs
       (old: {
+        buildCommand =
+          old.buildCommand
+          + ''
+            wrapProgram $out/bin/yosys \
+              --set YOSYS_PLUGIN_PATH $out/share/yosys/plugins
+          '';
         meta = (old.meta or { }) // {
           mainProgram = "yosys";
         };


### PR DESCRIPTION
Fixes plugin loading when using `plugin -i slang.so` in tcl scripts. Yosys resolves plugin paths via YOSYS_PLUGIN_PATH env var, not the wrapper's YOSYS_PATH which is only used for share resources.